### PR TITLE
Add registry instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,26 +69,32 @@ To run cluster:
 
 **macOS**
 
-```
+```bash
 # starts minikube
-minikube start --kubernetes-version=v1.14.0
+$ minikube start --kubernetes-version=v1.14.0
 # this command should work
-kubectl get nodes
+$ kubectl get nodes
 # use docker from minikube
-eval $(minikube docker-env)
+$ eval $(minikube docker-env)
 # this command to check connectivity
-docker ps
+$ docker ps
 ```
 
 **Linux**
 
-```
+```bash
 # starts minikube
-minikube start --kubernetes-version=v1.14.0 --vm-driver=kvm2
+$ minikube start --kubernetes-version=v1.14.0 --vm-driver=kvm2
 # this command should work
-kubectl get nodes
+$ kubectl get nodes
 # use docker from minikube
-eval $(minikube docker-env)
+$ eval $(minikube docker-env)
 # this command to check connectivity
-docker ps
+$ docker ps
+```
+
+## Configure registry
+
+```
+$ kubectl create -f registry.yaml
 ```

--- a/registry.yaml
+++ b/registry.yaml
@@ -19,3 +19,18 @@ spec:
       containers:
       - image: registry:2
         name: server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry
+  namespace: default
+  labels:
+    app: registry
+spec:
+  type: ClusterIP
+  ports:
+  - name: registry
+    port: 5000
+  selector:
+    app: registry


### PR DESCRIPTION
The instructions were missing on how to spin up registry inside minikube. Registry is needed for some exercises, e.g. prod patterns training.

Also add service for registry which is needed for `docker push` commands to work properly. Minikube configures docker with --insecure-registries set to service subnet so docker push must push to a service.