### PR TITLE
Update workshops for 6.1 release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Open source series of workshops delivered by Gravitational services team.
 * [Docker 101 workshop](docker.md)
 * [Kubernetes 101 workshop using Minikube and Mattermost](k8s101.md)
 * [Kubernetes production patterns](k8sprod.md)
+* [Kubernetes security patterns](k8ssecurity.md)
+* [Kubernetes custom resources](crd/crd.md)
 * [Gravity 101](gravity101.md)
 * [Gravity fire drill exercises](firedrills.md)
 
@@ -22,40 +24,54 @@ If you have macOS (Yosemite or newer), please download Docker for Mac [here](htt
 
 *Older docker package for OSes older than Yosemite -- Docker Toolbox located [here](https://www.docker.com/products/docker-toolbox).*
 
-### VirtualBox
+### Hypervisor
 
-Let’s install VirtualBox first.
+#### HyperKit [macOS only]
+
+HyperKit is a lightweight macOS hypervisor which minikube supports out of the box and which should be
+already installed on your machine if you have Docker for Desktop installed.
+
+More information: https://minikube.sigs.k8s.io/docs/reference/drivers/hyperkit/.
+
+Alternatively, install VirtualBox like described below.
+
+#### KVM2 [Linux only]
+
+Follow the instructions here: https://minikube.sigs.k8s.io/docs/reference/drivers/kvm2/.
+
+Alternatively, install VirtualBox like described below.
+
+#### VirtualBox [both macOS and Linux]
+
+Let’s install VirtualBox.
 
 Get latest stable version from https://www.virtualbox.org/wiki/Downloads.
 
-**Note:** When using Ubuntu you may need to disable Secure Boot. An alternative approach to installing with Secure Boot enabled, follow the guide [here](https://torstenwalter.de/virtualbox/ubuntu/2019/06/13/install-virtualbox-ubuntu-secure-boot.html). 
-
-### Linux: KVM2
-
-Follow the instructions here: https://minikube.sigs.k8s.io/docs/reference/drivers/kvm2/
+**Note:** When using Ubuntu you may need to disable Secure Boot. An alternative approach to installing with Secure Boot enabled,
+follow the guide [here](https://torstenwalter.de/virtualbox/ubuntu/2019/06/13/install-virtualbox-ubuntu-secure-boot.html).
 
 ### Kubectl
 
 For macOS:
 
-    curl -O https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/darwin/amd64/kubectl \
+    curl -O https://storage.googleapis.com/kubernetes-release/release/v1.16.2/bin/darwin/amd64/kubectl \
         && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 
 For Linux:
 
-    curl -O https://storage.googleapis.com/kubernetes-release/release/v1.15.2/bin/linux/amd64/kubectl \
+    curl -O https://storage.googleapis.com/kubernetes-release/release/v1.16.2/bin/linux/amd64/kubectl \
         && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 
 ### Minikube
 
 For macOS:
 
-    curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.3.1/minikube-darwin-amd64 \
+    curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.5.1/minikube-darwin-amd64 \
         && chmod +x minikube && sudo mv minikube /usr/local/bin/
 
 For Linux:
 
-    curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.3.1/minikube-linux-amd64 \
+    curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.5.1/minikube-linux-amd64 \
         && chmod +x minikube && sudo mv minikube /usr/local/bin/
 
 Also, you can install drivers for various VM providers to optimize your minikube VM performance.
@@ -73,7 +89,7 @@ To run cluster:
 
 ```bash
 # starts minikube
-$ minikube start --kubernetes-version=v1.15.2
+$ minikube start --kubernetes-version=v1.16.2
 # this command should work
 $ kubectl get nodes
 # use docker from minikube
@@ -86,7 +102,7 @@ $ docker ps
 
 ```bash
 # starts minikube
-$ minikube start --kubernetes-version=v1.15.2 --vm-driver=kvm2
+$ minikube start --kubernetes-version=v1.16.2 --vm-driver=kvm2
 # this command should work
 $ kubectl get nodes
 # use docker from minikube

--- a/firedrills.md
+++ b/firedrills.md
@@ -26,6 +26,9 @@ We can see that all Kubernetes processes appear to be running. However, if we tr
 
 ```bash
 node-1$ sudo systemctl status kube-apiserver
+● kube-apiserver.service
+   Loaded: not-found (Reason: No such file or directory)
+   Active: inactive (dead)
 ```
 
 Gravity provides a way to obtain a shell inside the Planet container:
@@ -130,14 +133,14 @@ Oftentimes it is useful to inspect the logs of these units, for example to figur
 
 ```bash
 node-1$ sudo systemctl list-unit-files | grep planet
-gravity__gravitational.io__planet__5.6.0-11305-10-g9e464aa.service enabled
+gravity__gravitational.io__planet__6.1.8-11505.service enabled
 ```
 
 Once we've found the service name, we can use `journalctl` to see its logs:
 
 ```
 node-1$ sudo journalctl \
-    -u gravity__gravitational.io__planet__5.6.0-11305-10-g9e464aa \
+    -u gravity__gravitational.io__planet__6.1.8-11505 \
     --no-pager
 ```
 
@@ -156,6 +159,11 @@ Most often than not, however, it is more convenient to just launch Gravity shell
 ```bash
 node-1$ sudo gravity shell
 node-1-planet$ systemctl list-unit-files | grep kube
+kube-apiserver.service                 static
+kube-controller-manager.service        static
+kube-kubelet.service                   static
+kube-proxy.service                     static
+kube-scheduler.service                 static
 node-1-planet$ journalctl -u kube-apiserver --no-pager
 node-1-planet$ journalctl -u kube-kubelet --no-pager
 ```
@@ -193,7 +201,8 @@ node-1$ kubectl -nkube-system logs corednx-xxx coredns
 The kubectl command works both from host and inside the planet environment. Inside the planet there is a convenient shorthand for `kubectl -nkube-system` - `kctl`.
 
 ```bash
-node-1$ sudo gravity exec kctl logs coredns-xxx
+node-1$ sudo gravity shell
+node-1-planet$ kctl logs coredns-xxx
 ```
 
 Another crucial pod runs the Gravity cluster controller. It has many responsibilities: handles cluster operations (expand, upgrade, etc.), keeps cluster-local registries in-sync, provides an API for the `gravity` command-line utility, serves as an authentication gateway and so on. It is called “gravity-site” and runs as a DaemonSet on master nodes.
@@ -361,7 +370,9 @@ Let's imagine we've got a cluster with a weird networking problem that manifests
 ```bash
 node-1$ kubectl exec -ti debug-jl8nr /bin/sh
 debug-pod$ curl -k https://gravity-site.kube-system.svc.cluster.local:3009/healthz
-// hangs, may produce result after a long while
+curl: (6) Could not resolve host: gravity-site.kube-system.svc.cluster.local
+debug-pod$ curl -k https://gravity-site.kube-system.svc.cluster.local:3009/healthz
+{"info":"service is up and running","status":"ok"}  # after a long while
 ```
 
 This service URL points to the active cluster controller (`gravity-site`) and is supposed to immediately return `200 OK` but the pod can no longer reach it. All pods seem to be running and healthy though:
@@ -388,7 +399,7 @@ Bingo! Satellite just saved us (possibly) hours of troubleshooting and pointed t
 node-1$ sudo sysctl -w net.ipv4.ip_forward=1
 ...
 debug-pod$ curl -k https://gravity-site.kube-system.svc.cluster.local:3009/healthz
-{"info":"service is up and running","status":"ok"}
+{"info":"service is up and running","status":"ok"}  # fast
 ...
 node-1$ gravity status
 ...
@@ -655,11 +666,13 @@ node-3$ sudo gravity exec tcpdump -n -l -i any host 10.244.4.21
 Obviously, replace the IP with the IP of your debug pod. Then, execute another `curl` from the debug container. One of the running `tcpdump` sessions should start producing output like this:
 
 ```
-19:19:28.678062 IP 10.244.4.21.44651 > gravity.domain: 46573+ A? gravity-site.kube-system.svc.cluster.local. (60)
-19:19:28.678130 IP 10.244.4.21.44651 > gravity.domain: 47613+ AAAA? gravity-site.kube-system.svc.cluster.local. (60)
+19:54:19.140739 IP 10.244.96.4.35584 > 10.100.72.196.53: 46011+ A? gravity-site.kube-system.svc.cluster.local.default.svc.cluster.local. (86)
+19:54:19.140788 IP 10.244.96.1 > 10.244.96.4: ICMP 10.100.72.196 udp port 53 unreachable, length 122
+19:54:19.140810 IP 10.244.96.4.35584 > 10.100.72.196.53: 24204+ AAAA? gravity-site.kube-system.svc.cluster.local.default.svc.cluster.local. (86)
+19:54:19.140818 IP 10.244.96.1 > 10.244.96.4: ICMP 10.100.72.196 udp port 53 unreachable, length 122
 ```
 
-We can now see DNS queries made by our debug pod to the DNS Kubernetes service IP but it produces no response - the traffic only flows one way. This means something's wrong with our in-cluster DNS service so let’s check our CoreDNS pods and their logs (do not forget to Ctrl-C `tcpdump` running on all nodes):
+We can now see DNS queries made by our debug pod to the DNS Kubernetes service IP but they receive "port unreachable" response. This means something's wrong with our in-cluster DNS service so let’s check our CoreDNS pods and their logs (do not forget to Ctrl-C `tcpdump` running on all nodes):
 
 ```bash
 node-1$ kubectl -nkube-system get pods -owide
@@ -765,22 +778,22 @@ To shut down the planet, find out its systemd unit name (note, that we’re on `
 
 ```bash
 node-3$ sudo systemctl list-unit-files | grep planet
-gravity__gravitational.io__planet__5.5.17-11305.service enabled
-node-3$ sudo systemctl stop gravity__gravitational.io__planet__5.5.17-11305.service
+gravity__gravitational.io__planet__6.1.8-11505.service enabled
+node-3$ sudo systemctl stop gravity__gravitational.io__planet__6.1.8-11505
 ```
 
 Once the planet has shut down, you can perform whatever maintenance necessary. Note that all Kubernetes services have shut down together with Planet:
 
 ```bash
-node-3$ ps aux
+node-3$ ps wwauxf
 ```
 
 But the Teleport actually keeps running:
 
 ```bash
 node-3$ systemctl list-unit-files | grep teleport
-gravity__gravitational.io__teleport__3.0.5.service      enabled
-node-3$ systemctl status gravity__gravitational.io__teleport__3.0.5.service
+gravity__gravitational.io__teleport__3.2.13.service    enabled
+node-3$ systemctl status gravity__gravitational.io__teleport__3.2.13
 ```
 
 Teleport node is still operational so it is possible to connect to it, for example via web terminal to perform maintenance if necessary.
@@ -804,7 +817,7 @@ node-1$ kubectl get nodes
 Keep in mind that if you restart the node, Planet will automatically start when the node boots up. Once the maintenance has been completed, let's bring Planet back up:
 
 ```bash
-node-3$ sudo systemctl start gravity__gravitational.io__planet__5.5.17-11305.service
+node-3$ sudo systemctl start gravity__gravitational.io__planet__6.1.8-11505
 ```
 
 It will take the cluster a minute or so to recover, after which let's uncordon the node and let Kubernetes start scheduling pods on it again:
@@ -837,6 +850,8 @@ As we found out before, a 3-node cluster can afford to lose 1 node so the cluste
 node-1$ gravity status
 node-1$ kubectl get nodes
 node-1$ sudo gravity exec etcdctl cluster-health
+...
+cluster is degraded
 ```
 
 We should note again here, that in our case we have (or had, rather) a 3-master HA cluster, thus we could afford to lose one of the masters. If we had a 3-node cluster with less than 3 masters, we would not have any etcd redundancy and wouldn't be able to afford the loss of a single master.

--- a/gravity101.md
+++ b/gravity101.md
@@ -71,13 +71,13 @@ Now let’s build the cluster image:
 ```bash
 build$ tele build ~/workshop/gravity101/v1-simplest/app.yaml
 * [1/6] Selecting base image version
-       Will use base image version 5.5.8
+       Will use base image version 6.1.10
 * [2/6] Downloading dependencies from https://get.gravitational.io
 * [3/6] Embedding application container images
        Detected application manifest app.yaml
        Found no images to vendor in application manifest app.yaml
-       Pulling remote image quay.io/gravitational/debian-tall:0.0.1
-       Vendored image gravitational/debian-tall:0.0.1
+       Pulling remote image quay.io/gravitational/debian-tall:buster
+       Vendored image gravitational/debian-tall:buster
 * [4/6] Creating application
 * [5/6] Generating the cluster snapshot
 * [6/6] Saving the snapshot as cluster-image-0.0.1.tar
@@ -98,8 +98,8 @@ The resulting file, `cluster-image-0.0.1.tar`, is our cluster image:
 
 ```bash
 build$ ls -lh
-total 1.3G
--rw-rw-r-- 1 ubuntu ubuntu 1.3G May 28 19:06 cluster-image-0.0.1.tar
+total 1.4G
+-rw-rw-r-- 1 ubuntu ubuntu 1.4G May 28 19:06 cluster-image-0.0.1.tar
 ```
 
 This image can now be transferred to a node or a set of nodes and used to install a Kubernetes cluster.
@@ -123,16 +123,22 @@ Let’s check:
 ```bash
 build$ tele version
 ...
-Version:        5.5.8
+Edition:	enterprise
+Version:	6.1.10
+Git Commit:	4c4ebfcb33c5b31dcc637b57edba18f5bf9ffbea
+Helm Version:	v2.14
 ```
 
 From the build progress output above we can see that `tele` picked matching base image. How do you know which Kubernetes is included into certain base image, or just explore available images in general? For this `tele` provides a list command:
 
 ```bash
 build$ tele ls
-Name:Version    Image Type      Created (UTC)           Description
-------------    ----------      -------------           -----------
-gravity:5.6.1   Cluster         2019-04-18 01:48        Base cluster image with Kubernetes v1.14.0
+Displaying latest stable versions of images. Use --all flag to show all.
+
+Name:Version	Image Type	Created (UTC)		Description
+------------	----------	-------------		-----------
+gravity:6.2.2	Cluster		2019-10-18 02:52	Base cluster image with Kubernetes v1.16.2
+hub:6.2.2	Cluster		2019-10-18 02:52	Remote cluster management and operations center
 ```
 
 The command displays the latest stable available cluster images; it also takes a `--all` flag to display everything.

--- a/gravity101.md
+++ b/gravity101.md
@@ -147,13 +147,13 @@ Note that the base image version does not match the version of included Kubernet
 
 How do you pick a base image? The Releases page is a good starting point as it contains a table with all current releases and changelog for each new patch release. As a general advice, most of the time you probably want the latest stable release. In some cases you may want to stick to the latest LTS release which may not have the latest features/Kubernetes but is more “battle-tested”.
 
-Now let’s say we’ve looked at all available runtimes and decided that we want to base our cluster image off of `5.5.8`. There are a couple of ways to go about this.
+Now let’s say we’ve looked at all available runtimes and decided that we want to base our cluster image off of `6.1.10`. There are a couple of ways to go about this.
 
-The first approach is to download `tele` version `5.5.8` and build the image using it. Our manifest still does not explicitly say which image to use so `tele` will default to `5.5.8`.
+The first approach is to download `tele` version `6.1.10` and build the image using it. Our manifest still does not explicitly say which image to use so `tele` will default to `6.1.10`.
 
 Another option is to “pin” the base image version explicitly in the manifest file. The advantage of this approach is that it eliminates the possibility of accidentally upgrading your runtime when upgrading the `tele` tool.
 
-Let’s look at the manifest that pins base image to version `5.5.8` explicitly:
+Let’s look at the manifest that pins base image to version `6.1.10` explicitly:
 
 ```bash
 build$ cat ~/workshop/gravity101/v1-with-base/app.yaml
@@ -162,7 +162,7 @@ build$ cat ~/workshop/gravity101/v1-with-base/app.yaml
 ```yaml
 apiVersion: cluster.gravitational.io/v2
 kind: Cluster
-baseImage: gravity:5.5.8
+baseImage: gravity:6.1.10
 metadata:
  name: cluster-image
  resourceVersion: 0.0.1
@@ -174,7 +174,7 @@ If we look at the difference between the two, we'll see that the new manifest sp
 build$ diff -y ~/workshop/gravity101/v1-simplest/app.yaml ~/workshop/gravity101/v1-with-base/app.yaml
 apiVersion: cluster.gravitational.io/v2                         apiVersion: cluster.gravitational.io/v2
 kind: Cluster                                                   kind: Cluster
-                                                              > baseImage: gravity:5.5.8
+                                                              > baseImage: gravity:6.1.10
 metadata:                                                       metadata:
  name: cluster-image                                             name: cluster-image
  resourceVersion: 0.0.1                                          resourceVersion: 0.0.1
@@ -260,7 +260,7 @@ Now that we’ve added the Helm chart, let’s try to build the image again:
 ```bash
 build$ tele build ~/workshop/gravity101/v1-with-resources/app.yaml --overwrite
 * [1/6] Selecting base image version
-       Will use base image version 6.0.0-alpha.1.61 set in manifest
+       Will use base image version 6.1.10 set in manifest
 * [2/6] Local package cache is up-to-date
 * [3/6] Embedding application container images
        Detected application manifest app.yaml
@@ -376,7 +376,7 @@ build$ cat ~/workshop/gravity101/v1/app.yaml
 ```yaml
 apiVersion: cluster.gravitational.io/v2
 kind: Cluster
-baseImage: gravity:5.5.8
+baseImage: gravity:6.1.10
 metadata:
   name: cluster-image
   resourceVersion: 0.0.1
@@ -391,7 +391,7 @@ If we compare our resulting manifest to the one we started with, we'll see all t
 build$ diff -y ~/workshop/gravity101/v1-simplest/app.yaml ~/workshop/gravity101/v1/app.yaml
 apiVersion: cluster.gravitational.io/v2                         apiVersion: cluster.gravitational.io/v2
 kind: Cluster                                                   kind: Cluster
-                                                              > baseImage: gravity:5.5.8
+                                                              > baseImage: gravity:6.1.10
 metadata:                                                       metadata:
  name: cluster-image                                             name: cluster-image
  resourceVersion: 0.0.1                                          resourceVersion: 0.0.1
@@ -547,7 +547,7 @@ Once this is done, all the nodes are bootstrapped and have their configuration p
 
 ```
 Wed May 22 20:45:32 UTC Install system software on master node node-1
-Wed May 22 20:45:33 UTC Install system package teleport:3.2.5 on master node node-1
+Wed May 22 20:45:33 UTC Install system package teleport:3.2.13 on master node node-1
 ```
 
 Teleport is a standalone Gravitational product. It is a drop-in SSH replacement that provides additional security and auditing features, such as short-lived certificates, role-based access control, recorded sessions and so on. Gravity uses Teleport to provide remote access to the cluster nodes. Teleport nodes run as systemd units on the cluster nodes.
@@ -555,7 +555,7 @@ Teleport is a standalone Gravitational product. It is a drop-in SSH replacement 
 Next service that’s being installed is called Planet:
 
 ```
-Wed May 22 20:45:34 UTC Install system package planet:6.0.1-11401 on master node node-1
+Wed May 22 20:45:34 UTC Install system package planet:6.1.8-11505 on master node node-1
 ```
 
 Planet, sometimes also referred to as “master container”, is a containerized Kubernetes distribution. This needs a bit more explaining.
@@ -596,9 +596,9 @@ At this point we have a fully-functional Kubernetes cluster but it does not have
 Wed May 22 20:46:48 UTC Install system application dns-app:0.3.0
 Wed May 22 20:47:02 UTC Install system application logging-app:5.0.2
 Wed May 22 20:47:15 UTC Install system application monitoring-app:6.0.1
-Wed May 22 20:47:38 UTC Install system application tiller-app:6.0.0
-Wed May 22 20:47:57 UTC Install system application site:6.0.0-alpha.1.61
-Wed May 22 20:48:50 UTC Install system application kubernetes:6.0.0-alpha.1.61
+Wed May 22 20:47:38 UTC Install system application tiller-app:6.1.0
+Wed May 22 20:47:57 UTC Install system application site:6.1.10
+Wed May 22 20:48:50 UTC Install system application kubernetes:6.1.10
 ```
 
 These system apps are a part of the base cluster image which, if you remember, we selected when we built our cluster image. They are always installed and provide basic in-cluster functionality such as in-cluster DNS, logging/monitoring facilities and Gravitational-specific cluster management plane and UI.
@@ -637,12 +637,12 @@ First, the `kubectl` binary - a main tool used to interact with Kubernetes - has
 node-1$ kubectl version
 ```
 
-Great! We’ve got Kubernetes 1.13.5 cluster. Now let’s see if our node has registered:
+Great! We’ve got Kubernetes `v1.15.5` cluster. Now let’s see if our node has registered:
 
 ```bash
 node-1$ kubectl get nodes
 NAME              STATUS   ROLES    AGE     VERSION
-192.168.121.197   Ready    <none>   2m58s   v1.14.1
+192.168.121.197   Ready    <none>   2m58s   v1.15.5
 ```
 
 And finally if we have anything running in the cluster:
@@ -657,8 +657,8 @@ Next, the `helm` binary has also been configured and made available for use on h
 
 ```bash
 node-1$ helm ls
-NAME            REVISION        UPDATED                         STATUS          CHART           APP VERSION     NAMESPACE
-nonplussed-cow  1               Thu May 23 17:30:45 2019        DEPLOYED        alpine-0.0.1                    kube-system
+NAME   	REVISION	UPDATED                 	STATUS  	CHART       	APP VERSION	NAMESPACE
+example	1       	Tue Oct 29 17:49:41 2019	DEPLOYED	alpine-0.0.1	           	kube-system
 ```
 
 Great, that works too.
@@ -724,12 +724,14 @@ We can now use `tsh` to interact with the cluster from the `build` box:
 build$ tsh ls
 build$ tsh ssh root@role=node
 node-1$ gravity status
+node-1$ exit
 ```
 
 Moreover, local `kubectl` on the `build` box has also been configured with proper credentials:
 
 ```bash
 build$ kubectl get nodes
+build$ kubectl get pods --all-namespaces -owide
 ```
 
 ### Configuring Cluster
@@ -828,7 +830,7 @@ Note the highlighted parts that have changed. Now our Helm chart will use versio
 build$ diff -y ~/workshop/gravity101/v1/app.yaml ~/workshop/gravity101/v2/app.yaml
 apiVersion: cluster.gravitational.io/v2                         apiVersion: cluster.gravitational.io/v2
 kind: Cluster                                                   kind: Cluster
-baseImage: gravity:5.5.8                                        baseImage: gravity:5.5.8
+baseImage: gravity:6.1.10                                       baseImage: gravity:6.1.10
 metadata:                                                       metadata:
  name: cluster-image                                             name: cluster-image
  resourceVersion: 0.0.1                                       |  resourceVersion: 0.0.2
@@ -906,6 +908,11 @@ In order to upgrade the cluster, we need to invoke the `upgrade` script found in
 
 ```bash
 node-1$ sudo ./upgrade
+Tue Oct 29 17:58:44 UTC	Importing application cluster-image v0.0.2
+Tue Oct 29 17:58:44 UTC	Synchronizing application with Docker registry 10.128.0.59:5000
+Tue Oct 29 17:58:57 UTC	Application has been uploaded
+Tue Oct 29 17:58:59 UTC	Upgrading application cluster-image from 0.0.1 to 0.0.2
+Tue Oct 29 17:58:59 UTC	Deploying upgrade agents on the nodes
 ```
 
 Once the upgrade is launched, it will take a few minutes to complete. Once it’s finished, let’s run `gravity status` to see that the cluster is now running the updated version:
@@ -918,6 +925,8 @@ And we can use `helm` too to confirm that our upgrade hook job has indeed upgrad
 
 ```bash
 node-1$ helm ls
+NAME   	REVISION	UPDATED                 	STATUS  	CHART       	APP VERSION	NAMESPACE
+example	2       	Tue Oct 29 17:59:19 2019	DEPLOYED	alpine-0.0.2	           	kube-system
 ```
 
 ## Expanding Cluster

--- a/gravity101/v1-with-base/app.yaml
+++ b/gravity101/v1-with-base/app.yaml
@@ -1,6 +1,6 @@
 apiVersion: cluster.gravitational.io/v2
 kind: Cluster
-baseImage: gravity:6.0.4
+baseImage: gravity:6.1.10
 metadata:
  name: cluster-image
  resourceVersion: 0.0.1

--- a/gravity101/v1-with-resources/app.yaml
+++ b/gravity101/v1-with-resources/app.yaml
@@ -1,6 +1,6 @@
 apiVersion: cluster.gravitational.io/v2
 kind: Cluster
-baseImage: gravity:6.0.4
+baseImage: gravity:6.1.10
 metadata:
  name: cluster-image
  resourceVersion: 0.0.1

--- a/gravity101/v1/app.yaml
+++ b/gravity101/v1/app.yaml
@@ -1,6 +1,6 @@
 apiVersion: cluster.gravitational.io/v2
 kind: Cluster
-baseImage: gravity:6.0.4
+baseImage: gravity:6.1.10
 metadata:
  name: cluster-image
  resourceVersion: 0.0.1

--- a/gravity101/v2/app.yaml
+++ b/gravity101/v2/app.yaml
@@ -1,6 +1,6 @@
 apiVersion: cluster.gravitational.io/v2
 kind: Cluster
-baseImage: gravity:6.0.4
+baseImage: gravity:6.1.10
 metadata:
  name: cluster-image
  resourceVersion: 0.0.2

--- a/gravity101/v3/app.yaml
+++ b/gravity101/v3/app.yaml
@@ -1,6 +1,6 @@
 apiVersion: cluster.gravitational.io/v2
 kind: Cluster
-baseImage: gravity:6.0.4
+baseImage: gravity:6.1.10
 metadata:
  name: cluster-image
  resourceVersion: 0.0.3

--- a/registry.yaml
+++ b/registry.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
A few updates to the workshops:

* Bump kubectl/minikube versions to the latest.
* Add information about HyperKit hypervisor.
* Update 101/firedrills for Gravity 6.1 and some polish/updates to the content.
