### PR TITLE
Fixed a few hiccups found during kube101 training

### DIFF
--- a/mattermost/postgres.yaml
+++ b/mattermost/postgres.yaml
@@ -12,3 +12,6 @@ spec:
     image: postgres:latest
     ports:
       - containerPort: 5432
+    env:
+      - name: POSTGRES_HOST_AUTH_METHOD
+        value: "trust"

--- a/mattermost/worker.yaml
+++ b/mattermost/worker.yaml
@@ -18,7 +18,7 @@ spec:
         role: mattermost-worker
     spec:
       containers:
-      - image: __REGISTRY_IP__/mattermost-worker:5.16.3
+      - image: __REGISTRY_IP__/mattermost-worker:5.21.0
         name: mattermost-worker
         ports:
         - containerPort: 80

--- a/mattermost/worker/Dockerfile
+++ b/mattermost/worker/Dockerfile
@@ -3,14 +3,17 @@
 FROM ubuntu:18.04
 
 # Copy over files
-ADD https://releases.mattermost.com/5.16.3/mattermost-team-5.16.3-linux-amd64.tar.gz /
-RUN cd /var && tar -zxvf /mattermost-team-5.16.3-linux-amd64.tar.gz && rm /mattermost-team-5.16.3-linux-amd64.tar.gz
+ADD https://releases.mattermost.com/5.21.0/mattermost-team-5.21.0-linux-amd64.tar.gz /
+RUN cd /var && tar -zxvf /mattermost-team-5.21.0-linux-amd64.tar.gz && rm /mattermost-team-5.21.0-linux-amd64.tar.gz
 
 ADD docker-entry.sh /var/mattermost/bin/docker-entry.sh
 RUN chmod +x /var/mattermost/bin/docker-entry.sh
 
 # Create default storage directory
 RUN mkdir /var/mattermost/data
+
+# link log file to stdout
+RUN ln -s /dev/stdout /var/mattermost/logs/mattermost.log
 
 ENTRYPOINT ["/var/mattermost/bin/docker-entry.sh"]
 

--- a/mattermost/worker/docker-entry.sh
+++ b/mattermost/worker/docker-entry.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cd /var/mattermost/bin
-./platform --config=/var/mattermost/config/config.json
+./mattermost --config=/var/mattermost/config/config.json


### PR DESCRIPTION
Fixed a few hiccups found during kube101 training, namely:
* postgresql auth issue
* Mattermost changed the binary used to start
* updated Mattermost version
* fixed Mattermost log not sending output to stdout