### PR TITLE
Clarify IP

### DIFF
--- a/k8s101.md
+++ b/k8s101.md
@@ -914,7 +914,7 @@ So on my computer, I can now open mattermost app using one of the nodes IP:
 
 ![mattermost](img/mattermost.png)
 
-When connecting via your browser, you'll need to use the IP of the VM that's in the same subnet of your host.  If you're using minikube, you can run `minikube tunnel` to get the right IP.  Combine that with the NodePort above.
+!!! MINIKUBE users: use `minikube tunnel` to fetch the IP address of the VM hosting Minikube.  When connecting via your browser, you'll need to use the IP of the VM that's in the same subnet of your host.  Combine that IP with the NodePort above.
 
 ## Recap
 

--- a/k8s101.md
+++ b/k8s101.md
@@ -909,11 +909,12 @@ NodePort:		http	32321/TCP
 
 Here we see that on our environment we should be able to connect to Mattermost by using `IP:32321` but on your system this port will most likely be different!
 
-So on my computer I can now open mattermost app using one of the nodes IP:
+So on my computer, I can now open mattermost app using one of the nodes IP:
 
 
 ![mattermost](img/mattermost.png)
 
+When connecting via your browser, you'll need to use the IP of the VM that's in the same subnet of your host.  If you're using minikube, you can run `minikube tunnel` to get the right IP.  Combine that with the NodePort above.
 
 ## Recap
 


### PR DESCRIPTION
Clarify that you need to use the IP of the VM in the same subnet of your host.  Adds a suggestion on how to get that IP for minikube users.