### PR TITLE
Terraform provisioning tweaks

### DIFF
--- a/env/.gitignore
+++ b/env/.gitignore
@@ -1,0 +1,2 @@
+*.tfstate
+*.tfstate.backup

--- a/env/Makefile
+++ b/env/Makefile
@@ -8,7 +8,6 @@ NODES ?= 3
 CREDS ?=
 
 # binaries to use
-AWS ?= aws
 TELE ?= tele
 TF ?= terraform
 
@@ -20,11 +19,6 @@ TF_DIR ?= terraform
 
 # path to the public SSH key file to put on GCE instances
 SSH_KEY_PATH ?=
-
-# parameters for AWS S3 terraform backend
-AWS_S3_REGION ?= us-east-1
-AWS_S3_BUCKET ?= training.gravitational.io
-AWS_S3_OPTS := --region $(AWS_S3_REGION) --acl public-read
 
 # exported terraform variables
 TF_VAR_node_tag := $(ENV)
@@ -79,9 +73,8 @@ refresh: check-env init
 .PHONY: init
 init: check-env
 	cd ${TF_DIR} && ${TF} init -reconfigure \
-	    -backend-config="region=$(AWS_S3_REGION)" \
-	    -backend-config="bucket=$(AWS_S3_BUCKET)" \
-	    -backend-config="key=terraform/$(ENV)/terraform.tfstate"
+		-backend-config="path=../$(ENV).tfstate"
+
 
 #
 # check-env makes sure ENV environment variable is set.

--- a/env/README.md
+++ b/env/README.md
@@ -4,12 +4,6 @@ for Gravity workshops.
 Each environment consists of 3 clean Ubuntu nodes suitable for installing
 Gravity cluster. The nodes are provisioned on GCE using terraform >= v0.12.
 
-Note, the terraform scripts use S3 backend to store terraform state, so valid
-AWS credentials should be available in the environment.
-
-To use the local backend instead, comment out the terraform backend section in
-the [config.tf](./terraform/config.tf) file.
-
 ### Usage Examples
 
 #### Provision Environment

--- a/env/README.md
+++ b/env/README.md
@@ -2,7 +2,7 @@ This directory contains a set of scripts for provisioning training environments
 for Gravity workshops.
 
 Each environment consists of 3 clean Ubuntu nodes suitable for installing
-Gravity cluster. The nodes are provisioned on GCE using terraform.
+Gravity cluster. The nodes are provisioned on GCE using terraform >= v0.12.
 
 Note, the terraform scripts use S3 backend to store terraform state, so valid
 AWS credentials should be available in the environment.

--- a/env/terraform/cluster.tf
+++ b/env/terraform/cluster.tf
@@ -1,49 +1,48 @@
 resource "google_compute_instance_group" "training" {
   description = "Instance group with all instances for the training"
   name        = "${var.node_tag}-grp"
-  zone        = "${var.zone}"
-  network     = "${data.google_compute_network.training.self_link}"
-  instances   = ["${google_compute_instance.cluster_node.*.self_link}"]
+  zone        = var.zone
+  network     = data.google_compute_network.training.self_link
+  instances   = google_compute_instance.cluster_node.*.self_link
 }
 
 resource "google_compute_instance" "cluster_node" {
   description  = "Node that will be a part of the cluster"
-  count        = "${var.nodes}"
+  count        = var.nodes
   name         = "${var.node_tag}-cluster-node-${count.index + 1}"
-  machine_type = "${var.cluster_instance_type}"
-  zone         = "${var.zone}"
+  machine_type = var.cluster_instance_type
+  zone         = var.zone
 
   tags = [
-    "${var.node_tag}",
+    var.node_tag,
   ]
 
-  labels {
-    cluster = "${var.node_tag}"
-    purpose = "${var.purpose}"
+  labels = {
+    cluster = var.node_tag
+    purpose = var.purpose
   }
 
   network_interface {
-    network = "${data.google_compute_network.training.self_link}"
+    network = data.google_compute_network.training.self_link
 
     access_config {
       # Ephemeral IP
     }
   }
 
-  metadata {
+  metadata = {
     # Enable OS login using IAM roles
     enable-oslogin = "true"
-
     # ssh-keys controls access to an instance using a custom SSH key
-    ssh-keys = "${var.os_user}:${file("${var.ssh_key_path}")}"
+    ssh-keys = "${var.os_user}:${file(var.ssh_key_path)}"
   }
 
-  metadata_startup_script = "${data.template_file.bootstrap_cluster_node.*.rendered[count.index]}"
+  metadata_startup_script = data.template_file.bootstrap_cluster_node[count.index].rendered
 
   boot_disk {
     initialize_params {
-      image = "${var.vm_image}"
-      type  = "${var.disk_type}"
+      image = var.vm_image
+      type  = var.disk_type
       size  = 50
     }
 
@@ -51,12 +50,12 @@ resource "google_compute_instance" "cluster_node" {
   }
 
   attached_disk {
-    source = "${google_compute_disk.etcd.*.self_link[count.index]}"
+    source = google_compute_disk.etcd[count.index].self_link
     mode   = "READ_WRITE"
   }
 
   attached_disk {
-    source = "${google_compute_disk.system.*.self_link[count.index]}"
+    source = google_compute_disk.system[count.index].self_link
     mode   = "READ_WRITE"
   }
 
@@ -69,37 +68,38 @@ resource "google_compute_instance" "cluster_node" {
 }
 
 resource "google_compute_disk" "etcd" {
-  count = "${var.nodes}"
+  count = var.nodes
   name  = "${var.node_tag}-disk-etcd-${count.index}"
-  type  = "${var.disk_type}"
-  zone  = "${var.zone}"
+  type  = var.disk_type
+  zone  = var.zone
   size  = 10
 
-  labels {
-    cluster = "${var.node_tag}"
-    purpose = "${var.purpose}"
+  labels = {
+    cluster = var.node_tag
+    purpose = var.purpose
   }
 }
 
 resource "google_compute_disk" "system" {
-  count = "${var.nodes}"
+  count = var.nodes
   name  = "${var.node_tag}-disk-system-${count.index}"
-  type  = "${var.disk_type}"
-  zone  = "${var.zone}"
+  type  = var.disk_type
+  zone  = var.zone
   size  = 50
 
-  labels {
-    cluster = "${var.node_tag}"
-    purpose = "${var.purpose}"
+  labels = {
+    cluster = var.node_tag
+    purpose = var.purpose
   }
 }
 
 data "template_file" "bootstrap_cluster_node" {
-  count = "${var.nodes}"
-  template = "${file("./bootstrap-cluster-node.sh.tpl")}"
+  count    = var.nodes
+  template = file("./bootstrap-cluster-node.sh.tpl")
 
-  vars {
-    ssh_user = "${var.os_user}"
+  vars = {
+    ssh_user = var.os_user
     hostname = "node-${count.index + 1}"
   }
 }
+

--- a/env/terraform/config.tf
+++ b/env/terraform/config.tf
@@ -64,5 +64,5 @@ provider "google" {
 }
 
 terraform {
-  backend "s3" {}
+  backend "local" {}
 }

--- a/env/terraform/config.tf
+++ b/env/terraform/config.tf
@@ -58,9 +58,9 @@ variable "credentials" {
 }
 
 provider "google" {
-  project     = "${var.project}"
-  region      = "${var.region}"
-  credentials = "${file(var.credentials)}"
+  project     = var.project
+  region      = var.region
+  credentials = file(var.credentials)
 }
 
 terraform {

--- a/env/terraform/network.tf
+++ b/env/terraform/network.tf
@@ -6,10 +6,11 @@ data "google_compute_network" "training" {
 
 resource "google_compute_firewall" "ssh" {
   name    = "${var.node_tag}-allow-ssh"
-  network = "${data.google_compute_network.training.self_link}"
+  network = data.google_compute_network.training.self_link
 
   allow {
     protocol = "tcp"
     ports    = ["22", "61822", "32009", "3009"]
   }
 }
+

--- a/env/terraform/output.tf
+++ b/env/terraform/output.tf
@@ -1,21 +1,28 @@
 output "node_1_private_ip" {
-  value = "${google_compute_instance.cluster_node.*.network_interface.0.network_ip[0]}"
+  value = google_compute_instance.cluster_node.*.network_interface.0.network_ip[0]
 }
+
 output "node_1_public_ip" {
-  value = "${google_compute_instance.cluster_node.*.network_interface.0.access_config.0.nat_ip[0]}"
+  value = google_compute_instance.cluster_node.*.network_interface.0.access_config.0.nat_ip[0]
 }
+
 output "node_2_private_ip" {
-  value = "${google_compute_instance.cluster_node.*.network_interface.0.network_ip[1]}"
+  value = google_compute_instance.cluster_node.*.network_interface.0.network_ip[1]
 }
+
 output "node_2_public_ip" {
-  value = "${google_compute_instance.cluster_node.*.network_interface.0.access_config.0.nat_ip[1]}"
+  value = google_compute_instance.cluster_node.*.network_interface.0.access_config.0.nat_ip[1]
 }
+
 output "node_3_private_ip" {
-  value = "${google_compute_instance.cluster_node.*.network_interface.0.network_ip[2]}"
+  value = google_compute_instance.cluster_node.*.network_interface.0.network_ip[2]
 }
+
 output "node_3_public_ip" {
-  value = "${google_compute_instance.cluster_node.*.network_interface.0.access_config.0.nat_ip[2]}"
+  value = google_compute_instance.cluster_node.*.network_interface.0.access_config.0.nat_ip[2]
 }
+
 output "csv" {
   value = "${google_compute_instance.cluster_node.*.network_interface.0.access_config.0.nat_ip[0]},${google_compute_instance.cluster_node.*.network_interface.0.network_ip[0]},${google_compute_instance.cluster_node.*.network_interface.0.access_config.0.nat_ip[1]},${google_compute_instance.cluster_node.*.network_interface.0.network_ip[1]},${google_compute_instance.cluster_node.*.network_interface.0.access_config.0.nat_ip[2]},${google_compute_instance.cluster_node.*.network_interface.0.network_ip[2]}"
 }
+

--- a/env/terraform/versions.tf
+++ b/env/terraform/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Two changes:

1) Upgrade terraform syntax for 0.12+.  These scripts no longer run on jenkins so 11.x compat isn't needed any longer. These changes wouldn't affect jenkins anyhow, as it uses the copy in the `ops` repo.
2) Remove S3 backend. For the one-off use case, we don't need to involve a second cloud.  Better to keep things simple and cut down an extra setup step.

## Testing Done
<details><summary>init, up, & down</summary>

```
walt@work:~/git/workshop/env$ make init ENV=walt-training
cd terraform && terraform init -reconfigure \
        -backend-config="path=../walt-training.tfstate"

Initializing the backend...
Do you want to copy existing state to the new backend?
  Pre-existing state was found while migrating the previous "local" backend to the
  newly configured "local" backend. No existing state was found in the newly
  configured "local" backend. Do you want to copy this state to the new "local"
  backend? Enter "yes" to copy and "no" to start with an empty state.

  Enter a value: no


Successfully configured the backend "local"! Terraform will automatically
use this backend unless the backend configuration changes.

Initializing provider plugins...

The following providers do not have any version constraints in configuration,
so the latest version was installed.

To prevent automatic upgrades to new major versions that may contain breaking
changes, it is recommended to add version = "..." constraints to the
corresponding provider blocks in configuration, with the constraint strings
suggested below.

* provider.google: version = "~> 3.5"
* provider.template: version = "~> 2.1"

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
walt@work:~/git/workshop/env$ make up ENV=walt-training
cd terraform && terraform init -reconfigure \
        -backend-config="path=../walt-training.tfstate"

Initializing the backend...

Successfully configured the backend "local"! Terraform will automatically
use this backend unless the backend configuration changes.

Initializing provider plugins...

The following providers do not have any version constraints in configuration,
so the latest version was installed.

To prevent automatic upgrades to new major versions that may contain breaking
changes, it is recommended to add version = "..." constraints to the
corresponding provider blocks in configuration, with the constraint strings
suggested below.

* provider.google: version = "~> 3.5"
* provider.template: version = "~> 2.1"

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
cd terraform && terraform apply -auto-approve
data.template_file.bootstrap_cluster_node[2]: Refreshing state...
data.template_file.bootstrap_cluster_node[1]: Refreshing state...
data.template_file.bootstrap_cluster_node[0]: Refreshing state...
data.google_compute_network.training: Refreshing state...
google_compute_firewall.ssh: Creating...
google_compute_disk.etcd[1]: Creating...
google_compute_disk.etcd[0]: Creating...
google_compute_disk.etcd[2]: Creating...
google_compute_disk.system[0]: Creating...
google_compute_disk.system[1]: Creating...
google_compute_disk.system[2]: Creating...
google_compute_disk.system[1]: Creation complete after 3s [id=projects/kubeadm-167321/zones/us-west1-c/disks/walt-training-disk-system-1]
google_compute_disk.etcd[1]: Creation complete after 3s [id=projects/kubeadm-167321/zones/us-west1-c/disks/walt-training-disk-etcd-1]
google_compute_disk.system[0]: Creation complete after 3s [id=projects/kubeadm-167321/zones/us-west1-c/disks/walt-training-disk-system-0]
google_compute_disk.system[2]: Creation complete after 3s [id=projects/kubeadm-167321/zones/us-west1-c/disks/walt-training-disk-system-2]
google_compute_disk.etcd[0]: Creation complete after 3s [id=projects/kubeadm-167321/zones/us-west1-c/disks/walt-training-disk-etcd-0]
google_compute_disk.etcd[2]: Creation complete after 4s [id=projects/kubeadm-167321/zones/us-west1-c/disks/walt-training-disk-etcd-2]
google_compute_instance.cluster_node[1]: Creating...
google_compute_instance.cluster_node[2]: Creating...
google_compute_instance.cluster_node[0]: Creating...
google_compute_firewall.ssh: Creation complete after 8s [id=projects/kubeadm-167321/global/firewalls/walt-training-allow-ssh]
google_compute_instance.cluster_node[1]: Creation complete after 8s [id=projects/kubeadm-167321/zones/us-west1-c/instances/walt-training-cluster-node-2]
google_compute_instance.cluster_node[2]: Creation complete after 8s [id=projects/kubeadm-167321/zones/us-west1-c/instances/walt-training-cluster-node-3]
google_compute_instance.cluster_node[0]: Creation complete after 8s [id=projects/kubeadm-167321/zones/us-west1-c/instances/walt-training-cluster-node-1]
google_compute_instance_group.training: Creating...
google_compute_instance_group.training: Creation complete after 5s [id=projects/kubeadm-167321/zones/us-west1-c/instanceGroups/walt-training-grp]

Apply complete! Resources: 11 added, 0 changed, 0 destroyed.

The state of your infrastructure has been saved to the path
below. This state is required to modify and destroy your
infrastructure, so keep it safe. To inspect the complete state
use the `terraform show` command.

State path: ../walt-training.tfstate

Outputs:

csv = 35.247.112.34,10.138.0.109,34.105.104.199,10.138.0.67,34.82.197.115,10.138.0.71
node_1_private_ip = 10.138.0.109
node_1_public_ip = 35.247.112.34
node_2_private_ip = 10.138.0.67
node_2_public_ip = 34.105.104.199
node_3_private_ip = 10.138.0.71
node_3_public_ip = 34.82.197.115
walt@work:~/git/workshop/env$ make down ENV=walt-training
cd terraform && terraform init -reconfigure \
        -backend-config="path=../walt-training.tfstate"

Initializing the backend...

Successfully configured the backend "local"! Terraform will automatically
use this backend unless the backend configuration changes.

Initializing provider plugins...

The following providers do not have any version constraints in configuration,
so the latest version was installed.

To prevent automatic upgrades to new major versions that may contain breaking
changes, it is recommended to add version = "..." constraints to the
corresponding provider blocks in configuration, with the constraint strings
suggested below.

* provider.google: version = "~> 3.5"
* provider.template: version = "~> 2.1"

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
cd terraform && terraform refresh
Empty or non-existent state file.

Refresh will do nothing. Refresh does not error or return an erroneous
exit status because many automation scripts use refresh, plan, then apply
and may not have a state file yet for the first run.

data.template_file.bootstrap_cluster_node[1]: Refreshing state...
data.template_file.bootstrap_cluster_node[0]: Refreshing state...
data.template_file.bootstrap_cluster_node[2]: Refreshing state...
data.google_compute_network.training: Refreshing state...
cd terraform && terraform destroy -auto-approve
data.template_file.bootstrap_cluster_node[2]: Refreshing state...
data.template_file.bootstrap_cluster_node[0]: Refreshing state...
data.template_file.bootstrap_cluster_node[1]: Refreshing state...
data.google_compute_network.training: Refreshing state...
google_compute_disk.etcd[2]: Refreshing state... [id=projects/kubeadm-167321/zones/us-west1-c/disks/walt-training-disk-etcd-2]
google_compute_disk.etcd[1]: Refreshing state... [id=projects/kubeadm-167321/zones/us-west1-c/disks/walt-training-disk-etcd-1]
google_compute_disk.etcd[0]: Refreshing state... [id=projects/kubeadm-167321/zones/us-west1-c/disks/walt-training-disk-etcd-0]
google_compute_disk.system[2]: Refreshing state... [id=projects/kubeadm-167321/zones/us-west1-c/disks/walt-training-disk-system-2]
google_compute_disk.system[1]: Refreshing state... [id=projects/kubeadm-167321/zones/us-west1-c/disks/walt-training-disk-system-1]
google_compute_disk.system[0]: Refreshing state... [id=projects/kubeadm-167321/zones/us-west1-c/disks/walt-training-disk-system-0]
google_compute_firewall.ssh: Refreshing state... [id=projects/kubeadm-167321/global/firewalls/walt-training-allow-ssh]
google_compute_instance.cluster_node[1]: Refreshing state... [id=projects/kubeadm-167321/zones/us-west1-c/instances/walt-training-cluster-node-2]
google_compute_instance.cluster_node[0]: Refreshing state... [id=projects/kubeadm-167321/zones/us-west1-c/instances/walt-training-cluster-node-1]
google_compute_instance.cluster_node[2]: Refreshing state... [id=projects/kubeadm-167321/zones/us-west1-c/instances/walt-training-cluster-node-3]
google_compute_instance_group.training: Refreshing state... [id=projects/kubeadm-167321/zones/us-west1-c/instanceGroups/walt-training-grp]
google_compute_firewall.ssh: Destroying... [id=projects/kubeadm-167321/global/firewalls/walt-training-allow-ssh]
google_compute_instance_group.training: Destroying... [id=projects/kubeadm-167321/zones/us-west1-c/instanceGroups/walt-training-grp]
google_compute_instance_group.training: Destruction complete after 3s
google_compute_instance.cluster_node[0]: Destroying... [id=projects/kubeadm-167321/zones/us-west1-c/instances/walt-training-cluster-node-1]
google_compute_instance.cluster_node[1]: Destroying... [id=projects/kubeadm-167321/zones/us-west1-c/instances/walt-training-cluster-node-2]
google_compute_instance.cluster_node[2]: Destroying... [id=projects/kubeadm-167321/zones/us-west1-c/instances/walt-training-cluster-node-3]
google_compute_firewall.ssh: Destruction complete after 7s
google_compute_instance.cluster_node[0]: Still destroying... [id=projects/kubeadm-167321/zones/us-west1-c/instances/walt-training-cluster-node-1, 10s elapsed]
google_compute_instance.cluster_node[1]: Still destroying... [id=projects/kubeadm-167321/zones/us-west1-c/instances/walt-training-cluster-node-2, 10s elapsed]
google_compute_instance.cluster_node[2]: Still destroying... [id=projects/kubeadm-167321/zones/us-west1-c/instances/walt-training-cluster-node-3, 10s elapsed]
google_compute_instance.cluster_node[2]: Destruction complete after 16s
google_compute_instance.cluster_node[0]: Still destroying... [id=projects/kubeadm-167321/zones/us-west1-c/instances/walt-training-cluster-node-1, 20s elapsed]
google_compute_instance.cluster_node[1]: Still destroying... [id=projects/kubeadm-167321/zones/us-west1-c/instances/walt-training-cluster-node-2, 20s elapsed]
google_compute_instance.cluster_node[1]: Destruction complete after 26s
google_compute_instance.cluster_node[0]: Destruction complete after 26s
google_compute_disk.etcd[2]: Destroying... [id=projects/kubeadm-167321/zones/us-west1-c/disks/walt-training-disk-etcd-2]
google_compute_disk.system[2]: Destroying... [id=projects/kubeadm-167321/zones/us-west1-c/disks/walt-training-disk-system-2]
google_compute_disk.system[0]: Destroying... [id=projects/kubeadm-167321/zones/us-west1-c/disks/walt-training-disk-system-0]
google_compute_disk.system[1]: Destroying... [id=projects/kubeadm-167321/zones/us-west1-c/disks/walt-training-disk-system-1]
google_compute_disk.etcd[1]: Destroying... [id=projects/kubeadm-167321/zones/us-west1-c/disks/walt-training-disk-etcd-1]
google_compute_disk.etcd[0]: Destroying... [id=projects/kubeadm-167321/zones/us-west1-c/disks/walt-training-disk-etcd-0]
google_compute_disk.etcd[0]: Destruction complete after 3s
google_compute_disk.etcd[1]: Destruction complete after 3s
google_compute_disk.system[1]: Destruction complete after 3s
google_compute_disk.system[2]: Destruction complete after 3s
google_compute_disk.system[0]: Destruction complete after 3s
google_compute_disk.etcd[2]: Destruction complete after 3s

Destroy complete! Resources: 11 destroyed.
walt@work:~/git/workshop/env$ ls
Makefile  README.md  terraform  walt-training.tfstate  walt-training.tfstate.backup
```

</details>
