### PR TITLE
Update k8s101.md

### DIFF
--- a/k8s101.md
+++ b/k8s101.md
@@ -13,7 +13,7 @@ Everyone says that Kubernetes (sometimes abbreviated as K8S) is hard, however go
 Let's start by creating an `nginx` service.
 
 ```bash
-$ kubectl run my-nginx --image=nginx --replicas=2 --port=80 --record
+$ kubectl create deployment my-nginx --image=nginx --replicas=2 --port=80
 $ kubectl expose deployment my-nginx --type=LoadBalancer --port=80
 ```
 


### PR DESCRIPTION
Replacing the deprecated syntax of the "kubectl run my-nginx --image=nginx --replicas=2 --port=80 --record" command with new format "kubectl create deployment my-nginx --image=nginx --replicas=2 --port=80"